### PR TITLE
Fixed hero section landscape overflow

### DIFF
--- a/assets/css/custom/rizin.css
+++ b/assets/css/custom/rizin.css
@@ -142,7 +142,7 @@
 }
 
 .hero-section {
-  padding: 0 var(--site-inner-padding);
+  padding: 30px;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/assets/css/custom/rizin.css
+++ b/assets/css/custom/rizin.css
@@ -182,6 +182,7 @@
 }
 
 .hero-section__separator {
+  padding: 15px 5px;
   background-color: var(--purple);
   line-height: 2;
   text-align: center;

--- a/assets/css/custom/rizin.css
+++ b/assets/css/custom/rizin.css
@@ -142,7 +142,6 @@
 }
 
 .hero-section {
-  height: 90vh;
   padding: 0 var(--site-inner-padding);
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
The `.hero-section` static height made it's descendants collapse with `.hero-section-seperator` on small viewports (<465px). 
Removing the height makes the element set it's height by the elements it contains.

I've also added padding to the separator so it'd be easy on the eyes 🤓

**Before:**
<img width="550" alt="Screen Shot 2020-12-10 at 11 43 53" src="https://user-images.githubusercontent.com/13344923/101755545-aaa42680-3add-11eb-9b7c-5c5d362a8bd9.png">

**After:**
<img width="550" alt="Screen Shot 2020-12-10 at 11 45 20" src="https://user-images.githubusercontent.com/13344923/101755600-bee82380-3add-11eb-886b-0eafc37774f2.png">

