### PR TITLE
Adds provision to open links in new tab

### DIFF
--- a/layouts/_default/community.html
+++ b/layouts/_default/community.html
@@ -24,7 +24,7 @@
         </p>
       </div>
       <div class="btn-team-members">
-        <a class="site-button btn-secondary" href="https://im.rizin.re/login">Join us on Mattermost</a>
+        <a class="site-button btn-secondary" target="_blank" href="https://im.rizin.re/login">Join us on Mattermost</a>
       </div>
     </div>
     <div class="team-item">
@@ -35,21 +35,21 @@
         </p>
       </div>
       <div class="btn-team-members">
-        <a class="site-button btn-secondary" href="https://t.me/rizinorg">Join us on Telegram</a>
+        <a class="site-button btn-secondary" target="_blank" href="https://t.me/rizinorg">Join us on Telegram</a>
       </div>
     </div>
     <div class="team-item">
       <div>
         <h3><mark>IRC</mark></h3>
         <p>
-          On Freenode (IRC), you can join <a href="https://webchat.freenode.net/?channels=#rizin">#rizin</a> for general discussions and <a href="https://webchat.freenode.net/?channels=#rizindev">#rizindev</a> for questions and discussions related to Rizin development.
+          On Freenode (IRC), you can join <a target="_blank" href="https://webchat.freenode.net/?channels=#rizin">#rizin</a> for general discussions and <a href="https://webchat.freenode.net/?channels=#rizindev" target="_blank">#rizindev</a> for questions and discussions related to Rizin development.
         </p>
         <p>
           Both are respectively bridged to the General and Rizin Dev channels on Mattermost.
         </p>
       </div>
       <div class="btn-team-members">
-        <a class="site-button btn-secondary" href="https://webchat.freenode.net/?channels=#rizin">Join us on IRC</a>
+        <a class="site-button btn-secondary" target="_blank" href="https://webchat.freenode.net/?channels=#rizin">Join us on IRC</a>
       </div>
     </div>
   </div>
@@ -65,7 +65,7 @@
         </p>
       </div>
       <div class="btn-team-members">
-        <a class="site-button btn-secondary" href="https://twitter.com/rizinorg">Follow us on Twitter</a>
+        <a class="site-button btn-secondary" target="_blank" href="https://twitter.com/rizinorg">Follow us on Twitter</a>
       </div>
     </div>
   </div>
@@ -81,7 +81,7 @@
         </p>
       </div>
       <div class="btn-team-members">
-        <a class="site-button btn-secondary" href="http://book.rizin.re">Read about Rizin</a>
+        <a class="site-button btn-secondary" target="_blank" href="http://book.rizin.re">Read about Rizin</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This Pull Request adds the feature to open the links present in the newly added community page in new tabs.
Basically, I've just added `target="_blank"` keyword to the links as specified earlier.