### PR TITLE
Fix spelling mistakes globally using Codespell

### DIFF
--- a/content/gsoc/2021.md
+++ b/content/gsoc/2021.md
@@ -531,7 +531,7 @@ A good example of transition is in these pull requests for `t` (types) command c
 
 Currently, Rizin's source code is rife with calls to `rz_core_cmd()`-like functions that run the Rizin command. While it is a useful shortcut for developer, it makes a good source of the potential bugs in case of the command syntax or behavior change. If these changes happen they are invisible to the compiler, so it cannot warn on the changed syntax. It isn't the case of changed function arguments count or type.
  Thus, all these calls eventually should be substituted with direct calls to the corresponding API
- functions. If there is no corresponding API funciton, then one should be created.
+ functions. If there is no corresponding API function, then one should be created.
  Good examples of such cases are:
  - [Refactor Graph processing from commands to the API use](https://github.com/rizinorg/rizin/issues/397)
  - [Refactor Visual mode from commands to the API use](https://github.com/rizinorg/rizin/issues/382)
@@ -544,7 +544,7 @@ In general you can just search for `rz_core_cmd` pattern in any place inside `li
 Rizin has its own intermediate language - ESIL, but not yet support it for all architectures. So
 the task is to add ESIL support to any architecture, which doesn't has it yet.
 
-## Miscellanous
+## Miscellaneous
 
 ### Shell (dietline) improvements
 

--- a/content/posts/introducing-projects/index.md
+++ b/content/posts/introducing-projects/index.md
@@ -138,7 +138,7 @@ What you see above is already an example of how the serialization will eventuall
 It is a simple, text-based format that stores the SDB entries line by line and takes care of any necessary escaping.
 While such a text-based format may not be the most efficient representation, it turned out to be more than good enough
 for even larger projects and in addition has certain nice properties, which we will make use of further down.
-However, due to the simplicity of SDB, other file formats to store the same data are theoretically feasable too.
+However, due to the simplicity of SDB, other file formats to store the same data are theoretically feasible too.
 
 ### Versioning
 


### PR DESCRIPTION
Fixed some minor spelling mistakes using Codespell.

`$ codespell -w --skip *.png --ignore-words-list kernal `