### PR TITLE
Fix typo ("portabilit" -> "portability")

### DIFF
--- a/content/gsoc/2023.md
+++ b/content/gsoc/2023.md
@@ -374,7 +374,7 @@ Participant will understand how high-level features of debuggers work as well as
 - [DWARF-labeled issues](https://github.com/rizinorg/rizin/labels/DWARF)
 - [PDB-labaled issues](https://github.com/rizinorg/rizin/labels/PDB)
 
-## Debugger improvements and portabilit (175 hour project)
+## Debugger improvements and portability (175 hour project)
 
 Rizin debugger already supports most of the platforms, including native and remote debugging.
 Nevertheless, for most platforms it's limited mostly to the x86/x86_64 and ARMv8, often lacking the

--- a/content/gsoc/2023.md
+++ b/content/gsoc/2023.md
@@ -306,7 +306,7 @@ implementation process.
 
 ### Benefits for the project
 Migrating most architectures will help to deprecate and remove outdated ESIL and will help improving the analysis precision.
-Adding uplifting for new architectures that weren't even supported by ESIL will imrove the
+Adding uplifting for new architectures that weren't even supported by ESIL will improve the
 analysis to even greater degree.
 
 ### Assess requirements for midterm/final evaluation


### PR DESCRIPTION
Fixed typos in GSoC 2023 ideas page.