### PR TITLE
changed .right class media query to align center

### DIFF
--- a/assets/css/custom/rizin.css
+++ b/assets/css/custom/rizin.css
@@ -287,10 +287,6 @@
   margin: auto;
 }
 
-.preview-section__feature .preview-section__feature__description.right {
-  text-align: center;
-}
-
 .preview-section__feature__visual {
   width: 100%;
   object-fit: cover;

--- a/assets/css/custom/rizin.css
+++ b/assets/css/custom/rizin.css
@@ -287,7 +287,7 @@
   margin: auto;
 }
 
-.preview-section__feature .preview-section__feature__description.right  {
+.preview-section__feature .preview-section__feature__description.right {
   text-align: right;
 }
 
@@ -460,12 +460,14 @@
     grid-template-rows: 1fr;
   }
 
-  .preview-section__feature .preview-section__feature__description {
+  .preview-section__feature .preview-section__feature__description,
+  .preview-section__feature .preview-section__feature__description.right {
     grid-row-start: 1;
     text-align: initial;
   }
 
-  .preview-section__feature:nth-child(even) .preview-section__feature__description {
+  .preview-section__feature:nth-child(even)
+    .preview-section__feature__description {
     grid-row-start: 1;
     grid-column-start: 1;
   }
@@ -526,7 +528,9 @@
 .community-icon svg:hover {
   fill: var(--purple-strong);
   -webkit-filter: drop-shadow(4px 4px 0px rgb(255, 157, 0));
-  filter: drop-shadow(4px 4px 0px rgb(255, 157, 0)); /* Same syntax as box-shadow */
+  filter: drop-shadow(
+    4px 4px 0px rgb(255, 157, 0)
+  ); /* Same syntax as box-shadow */
 }
 
 /* Grid spacing */

--- a/assets/css/custom/rizin.css
+++ b/assets/css/custom/rizin.css
@@ -288,7 +288,7 @@
 }
 
 .preview-section__feature .preview-section__feature__description.right {
-  text-align: right;
+  text-align: center;
 }
 
 .preview-section__feature__visual {
@@ -460,12 +460,13 @@
     grid-template-rows: 1fr;
   }
 
-  .preview-section__feature .preview-section__feature__description,
-  .preview-section__feature .preview-section__feature__description.right {
+  .preview-section__feature .preview-section__feature__description {
     grid-row-start: 1;
     text-align: initial;
   }
-
+  .preview-section__feature .preview-section__feature__description.right {
+    text-align: right;
+  }
   .preview-section__feature:nth-child(even)
     .preview-section__feature__description {
     grid-row-start: 1;


### PR DESCRIPTION
hey, 
found out that some headlines containing the ".right" class don't align to the center when media query is active. changed the CSS to match the requested design.